### PR TITLE
vm/agent_groups

### DIFF
--- a/tenable/io/base/schemas/filters/base.py
+++ b/tenable/io/base/schemas/filters/base.py
@@ -1,7 +1,7 @@
-from typing import Optional, Dict, List
-from marshmallow import Schema, ValidationError
-from tenable.io.base.session import TenableIO
 import re
+from typing import Dict, List, Optional
+
+from marshmallow import Schema, ValidationError
 
 
 class BaseFilterSchema(Schema):
@@ -14,7 +14,7 @@ class BaseFilterSchema(Schema):
 
     @classmethod
     def populate_filters(cls,
-                         tio: TenableIO,
+                         tio,
                          path: str,
                          envelope: str = 'filters',
                          force: bool = False,
@@ -44,7 +44,7 @@ class BaseFilterSchema(Schema):
             # then call the API using the TenableIO object provided and pull
             # down the filters.
             if not filters:
-                filters = tio.get(path)[envelope]
+                filters = tio.get(path).json()[envelope]
 
             # Reset the _filters dictionary to an empty dict object.
             cls._filters = {}

--- a/tenable/io/v3/base/schema/explore/filters.py
+++ b/tenable/io/v3/base/schema/explore/filters.py
@@ -3,7 +3,50 @@ Base Explore Filter Schema
 '''
 from typing import Dict, Tuple, Union
 
-from marshmallow import Schema, ValidationError, fields, pre_load
+from marshmallow import Schema, ValidationError, fields
+from marshmallow.decorators import pre_load, validates_schema
+
+from tenable.io.base.schemas.filters.base import BaseFilterSchema
+
+
+class ParseFilterSchema(BaseFilterSchema):
+    '''
+    Validate filter Schema class
+    '''
+    field = fields.Str(required=True)
+    operator = fields.Str(required=True)
+    value = fields.List(fields.Str(), required=True)
+    _filters = None
+
+    @classmethod
+    def populate_filters(cls, tio, path):
+        '''
+        Pre-populates the asset filter definitions into the RuleSchema class.
+        '''
+        super().populate_filters(tio, path)
+
+    @validates_schema
+    def filter_validation(self, data, **kwargs):
+        '''
+        Handles validation of the filter provided against the asset filter
+        definitions.
+        '''
+        self.validate_filter(data.get('field'),
+                             data.get('operator'),
+                             data.get('value'))
+
+    @pre_load(pass_many=False)
+    def tuple_expansion(self, data, **kwargs):
+        '''
+        Handles expanding a tuple definition into the dictionary equivalent.
+        '''
+        if isinstance(data, tuple):
+            return {
+                'field': data[0],
+                'operator': data[1],
+                'value': data[2]
+            }
+        return data
 
 
 class FilterSchema(Schema):

--- a/tenable/io/v3/vm/agent_groups/api.py
+++ b/tenable/io/v3/vm/agent_groups/api.py
@@ -403,8 +403,6 @@ class AgentGroupsAPI(ExploreBaseEndpoint):
                                             **kwargs) -> Dict:
         '''
         Create instructions for agents in an agent group to perform.
-        Instructions include restarting or changing local product
-        settings.
 
         :devportal:`bulk-operations: send-instructions-to-agent
         <io-agent-bulk-operations-directive>`
@@ -449,7 +447,7 @@ class AgentGroupsAPI(ExploreBaseEndpoint):
         Examples:
             Sending instruction to multiple agents:
 
-            >>> tio.v3.vm.agents.send_instruction_to_agents_in_group(
+            >>> tio.v3.vm.agent_groups.send_instruction_to_agents_in_group(
             ...     '00000000-0000-0000-0000-000000000000',
             ...     '334b962a-ac03-4336-9ebb-a06b169576e0',
             ...     directive_type = 'restart')

--- a/tenable/io/v3/vm/agent_groups/api.py
+++ b/tenable/io/v3/vm/agent_groups/api.py
@@ -336,8 +336,7 @@ class AgentGroupsAPI(ExploreBaseEndpoint):
                 results. This token is presented in the previous response.
             return_resp (bool, optional):
                 If set to true, will override the default behavior to return
-                an iterable and will instead return the results for the
-                specific page of data.
+                a requests.Response Object to the user.
             return_csv (bool, optional):
                 If set to true, it will return the CSV response or
                 iterable (based on return_resp flag). Iterator returns all
@@ -346,8 +345,8 @@ class AgentGroupsAPI(ExploreBaseEndpoint):
             Iterable:
                 The iterable that handles the pagination for the job.
             requests.Response:
-                If ``return_json`` was set to ``True``, then a response
-                object is instead returned instead of an iterable.
+                If ``return_resp`` is set to ``True``, then a response
+                object is returned instead of an iterable.
         Examples:
             >>> tio.v3.vm.agent_groups.search(
             ...     fields=['id', 'name'],

--- a/tenable/io/v3/vm/agent_groups/api.py
+++ b/tenable/io/v3/vm/agent_groups/api.py
@@ -14,8 +14,14 @@ Methods available on ``tio.v3.vm.agent_groups``:
 from typing import Dict, Union
 from uuid import UUID
 
+from requests import Response
+
 from tenable.io.v3.base.endpoints.explore import ExploreBaseEndpoint
-from tenable.io.v3.vm.agent_groups.schema import AgentGroupSchema
+from tenable.io.v3.base.iterators.explore_iterator import (CSVChunkIterator,
+                                                           SearchIterator)
+from tenable.io.v3.vm.agent_groups.schema import (AgentGroupFilterSchema,
+                                                  AgentGroupSchema)
+from tenable.utils import dict_clean
 
 
 class AgentGroupsAPI(ExploreBaseEndpoint):
@@ -184,13 +190,184 @@ class AgentGroupsAPI(ExploreBaseEndpoint):
                 json=payload
             )
 
-    def details(self):
-        raise NotImplementedError('This method will be updated later'
-                                  'once the filter API will develop')
+    def details(self, group_id: UUID, *filters, **kwargs) -> Dict:
+        '''
+        Retrieve the details about the specified agent group.
 
-    def search(self):
-        raise NotImplementedError('Search and Filter functionality '
-                                  'will be updated later.')
+        :devportal:`agent-groups: details <agent-groups-details>`
+
+        Args:
+            group_id (UUID): The unique identifier of the agent group.
+            *filters (tuple, optional):
+                Filters are tuples in the form of
+                ('NAME', 'OPERATOR', 'VALUE').
+                Multiple filters can be used and will filter down
+                the data being returned from the API.
+
+                Examples:
+                    - ``('distro', 'match', 'win')``
+                    - ``('name', 'nmatch', 'home')``
+
+                As the filters may change and sortable fields may change over
+                time, it's highly recommended that you look at the output of
+                the `filters:agents-filters <https://cloud.tenable.com/api#/
+                resources/filters/agents-filters>`_
+                endpoint to get more details.
+            filter_type (str, optional):
+                The filter_type operator determines how the filters are
+                combined together.  ``and`` will inform the API that all of
+                the filter conditions must be met for an agent to be returned,
+                whereas ``or`` would mean that if any of the conditions are
+                met, the agent record will be returned.
+            limit (int, optional):
+                The number of records to retrieve.  Default is 50
+            offset (int, optional):
+                The starting record to retrieve.  Default is 0.
+            scanner_id (int, optional):
+                The identifier the scanner that the agent communicates to.
+            sort (tuple, optional):
+                A tuple of tuples identifying the the field and sort order of
+                the field.
+            wildcard (str, optional):
+                A string to pattern match against all available fields returned
+            wildcard_fields (list, optional):
+                A list of fields to optionally restrict the wild-card matching
+                to.
+
+        Returns:
+            :obj:`dict`:
+                The dictionary object representing the requested agent group
+
+        Examples:
+            >>> group = tio.v3.vm.agent_groups.details(
+            ...     'ea81c0e9-a041-45d6-a654-80570d6bee97'
+            ... )
+            >>> pprint(group)
+        '''
+        payload: dict = dict_clean(kwargs)
+
+        # Let's fetch all the available filters for scan agent
+        if filters:
+            payload['filters'] = list(filters)
+            AgentGroupFilterSchema.populate_filters(
+                self._api, path='api/v3/definitions/scans/agents'
+            )
+
+        # Let's validate schema using marshmallow
+        payload = self._schema.dump(self._schema.load(payload))
+
+        # Let's build the query params
+        query: dict = {}
+        if 'filters' in payload:
+            query['f'] = []
+            for item in payload.get('filters'):
+                field = item['field']
+                oper = item['operator']
+                value = ','.join(item['value'])
+                query['f'].append(f'{field}:{oper}:{value}')
+
+        if 'sort' in payload:
+            query['sort'] = [f'{i[0]}:{i[1]}' for i in payload.get('sort')]
+
+        if 'filter_type' in payload:
+            query['ft'] = payload.get('filter_type')
+
+        if 'wildcard' in payload:
+            query['w'] = payload.get('wildcard')
+
+        if 'wildcard_fields' in payload:
+            query['wf'] = ','.join(payload.get('wildcard_fields'))
+
+        return self._get(f'{group_id}', params=query)
+
+    def search(self,
+               **kwargs) -> Union[SearchIterator, CSVChunkIterator, Response]:
+        '''
+        Search agent groups based on supported conditions.
+        Args:
+            fields (list, optional):
+                The list of field names to return from the Tenable API.
+                Example:
+                    >>> ['field1', 'field2']
+            filter (tuple, Dict, optional):
+                A nestable filter object detailing how to filter the results
+                down to the desired subset.
+                Examples:
+                    >>> ('or', ('and', ('test', 'oper', '1'),
+                    ...                 ('test', 'oper', '2')
+                    ...             ),
+                    ...     'and', ('test', 'oper', 3)
+                    ... )
+                    >>> {
+                    ...  'or': [{
+                    ...      'and': [{
+                    ...              'value': '1',
+                    ...              'operator': 'oper',
+                    ...              'property': '1'
+                    ...          },
+                    ...          {
+                    ...              'value': '2',
+                    ...              'operator': 'oper',
+                    ...              'property': '2'
+                    ...          }
+                    ...      ]
+                    ...  }],
+                    ...  'and': [{
+                    ...      'value': '3',
+                    ...      'operator': 'oper',
+                    ...      'property': 3
+                    ...  }]
+                    ... }
+                As the filters may change and sortable fields may change over
+                time, it's highly recommended that you look at the output of
+                the :py:meth:`tio.v3.definitions.vm.agent_groups()`
+                endpoint to get more details.
+            sort (list[tuple], optional):
+                A list of dictionaries describing how to sort the data
+                that is to be returned.
+                Examples:
+                    >>> [('field_name_1', 'asc'),
+                    ...      ('field_name_2', 'desc')]
+            limit (int, optional):
+                Number of objects to be returned in each request.
+                Default and max_limit is 200.
+            next (str, optional):
+                The pagination token to use when requesting the next page of
+                results. This token is presented in the previous response.
+            return_resp (bool, optional):
+                If set to true, will override the default behavior to return
+                an iterable and will instead return the results for the
+                specific page of data.
+            return_csv (bool, optional):
+                If set to true, it will return the CSV response or
+                iterable (based on return_resp flag). Iterator returns all
+                rows in text/csv format for each call with row headers.
+        Returns:
+            Iterable:
+                The iterable that handles the pagination for the job.
+            requests.Response:
+                If ``return_json`` was set to ``True``, then a response
+                object is instead returned instead of an iterable.
+        Examples:
+            >>> tio.v3.vm.agent_groups.search(
+            ...     fields=['id', 'name'],
+            ...     filter=('id', 'eq', [1,2]),
+            ...     sort=[('id', 'asc')],
+            ...     limit=10
+            ... )
+        '''
+        iclass = SearchIterator
+
+        if kwargs.get('return_csv', False):
+            iclass = CSVChunkIterator
+
+        return super()._search(
+            iterator_cls=iclass,
+            sort_type=self._sort_type.default,
+            api_path=f'{self._path}/search',
+            resource='agent_groups',
+            **kwargs
+        )
 
     def task_status(self, group_id: UUID, task_id: UUID) -> Dict:
         '''
@@ -218,3 +395,83 @@ class AgentGroupsAPI(ExploreBaseEndpoint):
             >>> pprint(task)
         '''
         return self._get(f'{group_id}/agents/_bulk/{task_id}')
+
+    def send_instruction_to_agents_in_group(self,
+                                            group_id: UUID,
+                                            *agent_ids: UUID,
+                                            directive_type: str,
+                                            **kwargs) -> Dict:
+        '''
+        Create instructions for agents in an agent group to perform.
+        Instructions include restarting or changing local product
+        settings.
+
+        :devportal:`bulk-operations: send-instructions-to-agent
+        <io-agent-bulk-operations-directive>`
+
+        Args:
+            group_id (UUID):
+                The unique identifier of the agent_group
+            *agent_ids (UUID):
+                The unique identifier of the agent
+            directive_type (str):
+                The type of instruction to perform.
+                Possible instructions are ``restart`` and ``settings``.
+            all_agents (bool, optional):
+                Indicates whether or not to match against all agents.
+            wildcard (str, optional):
+                A string used to match against all string-like attributes
+                of an agent.
+            filters (list, optional):
+                An array of string or numeric operations to match against
+                agents.
+                For Example:
+                    - ``['field:operator:value', 'name:match:laptop']``
+            filter_type (str, optional):
+                Indicates how to combine the filters conditions.
+                Possible values are ``and`` or ``or``.
+            hardcoded_filters (list, optional):
+                Additional filters that will always be added as
+                ``and`` conditions.
+            not_items (list, optional):
+                An array of agent IDs or UUIDs to exclude from the criteria
+                filter.
+            options (dict, optional):
+                Additional information about the instruction to perform.
+                For example:
+                    if the type is ``restart`` you can use the options
+                    ``'hard': true`` or ``'idle': true``.
+        Returns:
+            :obj:`dict`:
+                Returned dict if Tenable.io successfully creates
+                the bulk operation task.
+
+        Examples:
+            Sending instruction to multiple agents:
+
+            >>> tio.v3.vm.agents.send_instruction_to_agents_in_group(
+            ...     '00000000-0000-0000-0000-000000000000',
+            ...     '334b962a-ac03-4336-9ebb-a06b169576e0',
+            ...     directive_type = 'restart')
+        '''
+        payload: dict = {
+            'criteria': {
+                'all_agents': kwargs.get('all_agents'),
+                'wildcard': kwargs.get('wildcard'),
+                'filters': kwargs.get('filters'),
+                'filter_type': kwargs.get('filter_type'),
+                'hardcoded_filters': kwargs.get('hardcoded_filters')
+            },
+            'items': [item for item in agent_ids] or None,
+            'not_items': kwargs.get('not_items'),
+            'directive': {
+                'type': directive_type,
+                'options': kwargs.get('options')
+            }
+        }
+        payload = dict_clean(payload)
+
+        # Let's validate the schema using marshmallow
+        payload = self._schema.dump(self._schema.load(payload))
+
+        return self._post(f'{group_id}/agents/_bulk/directive', json=payload)

--- a/tenable/io/v3/vm/agent_groups/schema.py
+++ b/tenable/io/v3/vm/agent_groups/schema.py
@@ -1,7 +1,40 @@
 '''
 Agent Groups API Endpoint Schemas
 '''
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validate
+
+from tenable.io.v3.base.schema.explore.filters import ParseFilterSchema
+
+
+class CriteriaSchema(Schema):
+    '''
+    Supportive Schema for AgentSchema
+    '''
+    all_agents = fields.Bool()
+    wildcard = fields.Str()
+    filters = fields.List(fields.Str())
+    filter_type = fields.Str(
+        validate=validate.OneOf(['and', 'or'])
+    )
+    hardcoded_filters = fields.List(fields.Str())
+
+
+class DirectiveSchema(Schema):
+    '''
+    Supportive schema for AgentSchema
+    '''
+    type = fields.Str(
+        validate=validate.OneOf(['restart', 'settings']),
+        required=True
+    )
+    option = fields.Dict()
+
+
+class AgentGroupFilterSchema(ParseFilterSchema):
+    '''
+    Validate filters using ParseFilterSchema
+    '''
+    _filters = None
 
 
 class AgentGroupSchema(Schema):
@@ -10,3 +43,22 @@ class AgentGroupSchema(Schema):
     '''
     name = fields.Str()
     items_ = fields.List(fields.UUID(), data_key='items')
+    filters = fields.List(fields.Nested(AgentGroupFilterSchema))
+    wildcard = fields.Str()
+    filter_type = fields.Str(
+        validate=validate.OneOf(['and', 'or'])
+    )
+    wildcard_fields = fields.List(fields.Str())
+    sort = fields.List(
+        fields.Tuple(
+            (
+                fields.Str(),
+                fields.Str(validate=validate.OneOf(['asc', 'desc']))
+            )
+        )
+    )
+    limit = fields.Int()
+    offset = fields.Int()
+    not_items = fields.List(fields.UUID())
+    criteria = fields.Nested(CriteriaSchema)
+    directive = fields.Nested(DirectiveSchema)

--- a/tests/io/v3/vm/agent_groups/objects.py
+++ b/tests/io/v3/vm/agent_groups/objects.py
@@ -1,0 +1,47 @@
+NEGATIVE_CRITERIA_SCHEMA = [
+    {'all_agents': 'invalid'},
+    {'invalid': 'key'},
+    {'wildcard': 123},
+    {'filters': 123},
+    {'filters': [True]},
+    {'filter_type': False},
+    {'filter_type': 'invalid'},
+    {'hardcoded_filters': 123},
+    {'hardcoded_filters': [123]},
+]
+
+NEGATIVE_DIRECTIVE_SCHEMA = [
+    {'invalid': 'key'},
+    {'type': 123},
+    {'type': 'invalid'},
+    {'type': 'restart', 'option': 'invalid'},
+    {'option': {}}
+]
+
+NEGATIVE_AGENT_GROUP_FILTER_SCHEMA = [
+    {'invalid': 'key'}
+]
+
+NEGATIVE_AGENT_GROUP_SCHEMA = [
+    {'invalid': 'key'},
+    {'items': 'invalid'},
+    {'items': ['invalid']},
+    {'wildcard': 123},
+    {'filter_type': True},
+    {'filter_type': 'invalid'},
+    {'wildcard_fields': 123},
+    {'wildcard_fields': [123]},
+    {'sort': True},
+    {'sort': ['invalid']},
+    {'sort': [(True, 'asc')]},
+    {'sort': [('value', 123)]},
+    {'sort': [('value', 'invalid')]},
+    {'limit': 'invalid'},
+    {'offset': 'invalid'},
+    {'not_items': 'invalid'},
+    {'not_items': ['invalid']},
+    {'criteria': True},
+    {'criteria': {'invalid': 'key'}},
+    {'directive': {'invalid': 'key'}},
+    {'directive': 123}
+]

--- a/tests/io/v3/vm/agent_groups/test_agent_groups_api.py
+++ b/tests/io/v3/vm/agent_groups/test_agent_groups_api.py
@@ -4,10 +4,14 @@ test plugins
 import re
 from uuid import UUID
 
-import pytest
 import responses
+from requests import Response
+
+from tenable.io.v3.base.iterators.explore_iterator import (CSVChunkIterator,
+                                                           SearchIterator)
 
 BASE_URL = 'https://cloud.tenable.com/api/v3/agent-groups'
+AGENT_FILTER_URL = 'https://cloud.tenable.com/api/v3/definitions/scans/agents'
 
 
 @responses.activate
@@ -72,22 +76,18 @@ def test_configure(api):
     name: str = 'test name 2'
     payload = {'name': name}
     test_response = {
-        'agent_groups': [
-            {
-                'owner_id': '2e3a71fc-2442-4024-9fee-085cc61750cb',
-                'created': 1595001140400,
-                'modified': 1595001217809,
-                'container_id': 'd6c3e937-4467-4171-92d8-debf5ef3c917',
-                'id': 'e069b272-ed76-487a-8cf9-1c32836698b7',
-                'name': name,
-                'agents_count': 0,
-                'default_permissions': 16,
-                'shared': 1,
-                'user_permissions': 128,
-                'created_in_seconds': 1595001140,
-                'modified_in_seconds': 1595001217
-            }
-        ]
+        'id': group_id,
+        'name': name,
+        'creation_date': '2022-01-31T06:18:45Z',
+        'last_modification_date': '2022-01-31T06:18:45Z',
+        'timestamp': '2022-01-31T06:18:45Z',
+        'shared': 0,
+        'owner': {
+            'owner_id': '3bfcfb11-6c12-405b-b7ba-bbc705cd2a6e',
+            'owner_name': 'system'
+        },
+        'user_permissions': 0,
+        'agents_count': 0
     }
     responses.add(
         responses.PUT,
@@ -97,7 +97,7 @@ def test_configure(api):
     )
     res = api.v3.vm.agent_groups.configure(group_id, name)
     assert isinstance(res, dict)
-    assert res['agent_groups'][0]['name'] == name
+    assert res['name'] == name
 
 
 @responses.activate
@@ -105,24 +105,20 @@ def test_create(api):
     '''
     Test case for create method
     '''
-    name: str = 'test'
+    name: str = 'Agent Group 1'
     test_response: dict = {
-        'agent_groups': [
-            {
-                'id': 'ef62870e-fe2f-4ba9-98b7-43d3a53ffe85',
-                'name': name,
-                'creation_date': 1635756224,
-                'last_modification_date': 1635756224,
-                'timestamp': 1635756224,
-                'shared': 1,
-                'owner': {
-                    'name': 'system',
-                    'id': '3bfcfb11-6c12-405b-b7ba-bbc705cd2a6e'
-                },
-                'user_permissions': 128,
-                'agents_count': 0
-            }
-        ]
+        'id': 'd1bdf0b4-f31d-4147-af83-9d528c86ea66',
+        'name': name,
+        'creation_date': '2022-01-31T06:18:45Z',
+        'last_modification_date': '2022-01-31T06:18:45Z',
+        'timestamp': '2022-01-31T06:18:45Z',
+        'shared': 0,
+        'owner': {
+            'owner_id': '3bfcfb11-6c12-405b-b7ba-bbc705cd2a6e',
+            'owner_name': 'system'
+        },
+        'user_permissions': 0,
+        'agents_count': 0
     }
     responses.add(
         responses.POST,
@@ -132,7 +128,7 @@ def test_create(api):
     )
     res = api.v3.vm.agent_groups.create(name)
     assert isinstance(res, dict)
-    assert res['agent_groups'][0]['name'] == name
+    assert res['name'] == name
 
 
 @responses.activate
@@ -215,8 +211,8 @@ def test_task_status(api):
         'container_id': 'cfdabb09-6aef-481d-b28f-aecb1c38f297',
         'status': 'COMPLETED',
         'message': 'Finished bulk addToGroup operation.',
-        'start_time': 1638807034721,
-        'end_time': 1638807034730,
+        'start_time': '2022-01-31T06:18:45Z',
+        'end_time': '2022-01-31T06:19:45Z',
         'total_work_units_completed': 0
     }
     responses.add(
@@ -235,8 +231,106 @@ def test_details(api):
     '''
     Test case for details method
     '''
-    with pytest.raises(NotImplementedError):
-        api.v3.vm.agent_groups.details()
+    group_id: UUID = 'ea81c0e9-a041-45d6-a654-80570d6bee97'
+    filters: tuple = ('platform', 'match', ['window'])
+    filter_type: str = 'and'
+    limit: int = 50
+    offset: int = 0
+    sort: list = [('name', 'asc')]
+    wildcard: str = 'IYKKQIGOBWXUXOZIBURFENPNMGZOSWBUKVCD'
+    wildcard_fields: list = ['name']
+
+    test_response: dict = {
+        'id': group_id,
+        'name': 'Western Region',
+        'creation_date': '2022-01-31T06:18:45Z',
+        'last_modification_date': '2022-01-31T06:18:45Z',
+        'timestamp': '2022-01-31T06:18:45Z',
+        'shared': 1,
+        'owner': {
+            'name': 'system',
+            'id': '1bd703af-b2aa-4a82-ad8d-b883381a873f'
+        },
+        'user_permissions': 128,
+        'agents_count': 0,
+        'agents': [],
+        'pagination': {
+            'total': 0,
+            'limit': 50,
+            'offset': 0,
+            'sort': [
+                {
+                    'name': 'name',
+                    'order': 'asc'
+                }
+            ]
+        }
+    }
+
+    # Let's register the response for agents filter endpoint
+    responses.add(
+        responses.GET,
+        f'{AGENT_FILTER_URL}',
+        json={
+            'wildcard_fields': [
+                'core_version',
+                'distro',
+                'groups',
+                'ip',
+                'name',
+                'platform',
+                'status'
+            ],
+            'filters': [
+                {
+                    'name': 'platform',
+                    'readable_name': 'Platform',
+                    'operators': [
+                        'eq',
+                        'neq',
+                        'match',
+                        'nmatch'
+                    ],
+                    'control': {
+                        'readable_regex': 'Platform Name (e.g. Linux)',
+                        'type': 'entry',
+                        'regex': '.*'
+                    }
+                }
+            ],
+            'sort': {
+                'sortable_fields': [
+                    'core_version',
+                    'distro',
+                    'ip',
+                    'last_connect',
+                    'last_scanned',
+                    'name',
+                    'platform',
+                    'plugin_feed_id'
+                ]
+            }
+        }
+    )
+
+    responses.add(
+        responses.GET,
+        f'{BASE_URL}/{group_id}',
+        json=test_response
+    )
+
+    res = api.v3.vm.agent_groups.details(
+        group_id,
+        filters,
+        filter_type=filter_type,
+        limit=limit,
+        offset=offset,
+        sort=sort,
+        wildcard=wildcard,
+        wildcard_fields=wildcard_fields
+    )
+    assert isinstance(res, dict)
+    assert res['id'] == group_id
 
 
 @responses.activate
@@ -244,5 +338,147 @@ def test_search(api):
     '''
     Test case for search method
     '''
-    with pytest.raises(NotImplementedError):
-        api.v3.vm.agent_groups.search()
+    test_response: dict = {
+        'agent_groups': [
+            {
+                'id': '801cc413-bae9-4b84-b53c-f4b86056b9fd',
+                'name': 'test-007',
+                'creation_date': '2022-01-06T17:19:52Z',
+                'last_modification_date': '2022-01-06T17:19:52Z',
+                'timestamp': '2022-01-06T17:19:52Z',
+                'shared': 0,
+                'owner': {
+                    'owner_id': '3bfcfb11-6c12-405b-b7ba-bbc705cd2a6e',
+                    'owner_name': 'system'
+                },
+                'user_permissions': 0,
+                'agents_count': 1
+            }
+        ],
+        'pagination': {
+            'next': 'nextToken',
+            'total': 1
+        }
+    }
+
+    fields: list = [
+        'name',
+        'id',
+        'created',
+        'modified',
+        'owner_id',
+        'agents_count'
+    ]
+
+    filter = {
+        'and': [{
+            'property': 'modified',
+            'operator': 'date-eq',
+            'value': '2021-06-25T15:19:24Z'
+        }]
+    }
+
+    sort = [('name', 'asc')]
+
+    # Let's create sample payload for search exclusion endpoint
+    payload = {
+        'fields': fields,
+        'filter': filter,
+        'limit': 200,
+        'sort': [{'name': 'asc'}],
+    }
+
+    # Let's register the mock response for search endpoint
+    responses.add(
+        responses.POST,
+        f'{BASE_URL}/search',
+        json=test_response,
+        match=[responses.matchers.json_params_matcher(payload)],
+    )
+
+    iterator = api.v3.vm.agent_groups.search(
+        fields=fields, filter=filter, sort=sort, limit=200
+    )
+    assert isinstance(iterator, SearchIterator)
+
+    exclusions_list = []
+    for item in iterator:
+        exclusions_list.append(item)
+    assert len(exclusions_list) == test_response['pagination']['total']
+
+    iterator = api.v3.vm.agent_groups.search(
+        fields=fields, filter=filter, sort=sort, return_csv=True
+    )
+    assert isinstance(iterator, CSVChunkIterator)
+
+    resp = api.v3.vm.agent_groups.search(
+        fields=fields, filter=filter, sort=sort, return_resp=True, limit=200
+    )
+    assert isinstance(resp, Response)
+
+
+@responses.activate
+def test_send_instruction_to_agents_in_group(api):
+    '''
+    Test case for Agents send_instruction_to_agents_in_group method
+    '''
+    group_id: UUID = 'ea81c0e9-a041-45d6-a654-80570d6bee97'
+    all_agents: bool = True
+    wildcard: str = 'sdfknskdnf'
+    filters: list = ['name:match:laptop']
+    filter_type: str = 'and'
+    hardcoded_filters: list = ['core_version:lt:10.0.0']
+    not_items: list = ['334b962a-ac03-4336-9ebb-a06b321576e0']
+    directive_type: str = 'restart'
+
+    test_response: dict = {
+        "task_id": "7aaae2f3-544d-497f-b0f0-447d03d7cd55",
+        "container_id": "3cc182bb-b8ba-4025-9e59-9a81b8a64d5a",
+        "status": "RUNNING",
+        "message": "Starting...",
+        "start_time": '2022-01-18T10:36:44Z',
+        "last_update_time": '2022-01-18T10:36:44Z',
+        "total_work_units": 3,
+        "total_work_units_completed": 0,
+        "completion_percentage": 0
+    }
+
+    payload: dict = {
+        'items': [
+            '334b962a-ac03-4336-9ebb-a06b169576e0'
+        ],
+        'not_items': not_items,
+        'criteria': {
+            'all_agents': all_agents,
+            'filters': filters,
+            'hardcoded_filters': hardcoded_filters,
+            'wildcard': wildcard,
+            'filter_type': filter_type
+        },
+        'directive': {
+            'type': directive_type
+        }
+    }
+
+    # let's register the response for api endpoint
+    responses.add(
+        responses.POST,
+        re.compile(f'{BASE_URL}/{group_id}/agents/_bulk/directive'),
+        match=[responses.matchers.json_params_matcher(payload)],
+        json=test_response
+    )
+
+    res = api.v3.vm.agent_groups.send_instruction_to_agents_in_group(
+        group_id,
+        '334b962a-ac03-4336-9ebb-a06b169576e0',
+        directive_type='restart',
+        all_agents=True,
+        wildcard='sdfknskdnf',
+        filters=['name:match:laptop'],
+        filter_type='and',
+        hardcoded_filters=['core_version:lt:10.0.0'],
+        not_items=['334b962a-ac03-4336-9ebb-a06b321576e0']
+    )
+
+    assert isinstance(res, dict)
+    assert 'task_id' in list(res.keys())

--- a/tests/io/v3/vm/agent_groups/test_agent_groups_api.py
+++ b/tests/io/v3/vm/agent_groups/test_agent_groups_api.py
@@ -1,5 +1,5 @@
 '''
-test plugins
+Test cases agent groups API
 '''
 import re
 from uuid import UUID
@@ -17,7 +17,7 @@ AGENT_FILTER_URL = 'https://cloud.tenable.com/api/v3/definitions/scans/agents'
 @responses.activate
 def test_add_agent_with_single_agent_id(api):
     '''
-    Test case for add_agent method with sigle agent id
+    Test case for agent groups add_agent method with sigle agent id
     '''
     group_id: UUID = '2b2db604-5d92-11ec-bf63-0242ac130002'
     agent_id: UUID = '3f8eed68-5d95-11ec-bf63-0242ac130002'
@@ -32,7 +32,7 @@ def test_add_agent_with_single_agent_id(api):
 @responses.activate
 def test_add_agent_with_multiple_agent_id(api):
     '''
-    Test case for add_agent method with multiple agent id
+    Test case for agent groups add_agent method with multiple agent id
     '''
     group_id: UUID = '2b2db604-5d92-11ec-bf63-0242ac130002'
     payload = {
@@ -70,7 +70,7 @@ def test_add_agent_with_multiple_agent_id(api):
 @responses.activate
 def test_configure(api):
     '''
-    Test case for configure method
+    Test case for agent groups configure method
     '''
     group_id: UUID = 'e069b272-ed76-487a-8cf9-1c32836698b7'
     name: str = 'test name 2'
@@ -103,7 +103,7 @@ def test_configure(api):
 @responses.activate
 def test_create(api):
     '''
-    Test case for create method
+    Test case for agent groups create method
     '''
     name: str = 'Agent Group 1'
     test_response: dict = {
@@ -134,7 +134,7 @@ def test_create(api):
 @responses.activate
 def test_delete(api):
     '''
-    Test case for delete method
+    Test case for agent groups delete method
     '''
     group_id: UUID = 'e069b272-ed76-487a-8cf9-1c32836698b7'
     responses.add(
@@ -149,7 +149,7 @@ def test_delete(api):
 @responses.activate
 def test_delete_agent_with_single_agent_id(api):
     '''
-    Test case for delete_agent method
+    Test case for agent groups delete_agent method
     '''
     group_id: UUID = '2b2db604-5d92-11ec-bf63-0242ac130002'
     agent_id: UUID = '3f8eed68-5d95-11ec-bf63-0242ac130002'
@@ -164,7 +164,7 @@ def test_delete_agent_with_single_agent_id(api):
 @responses.activate
 def test_delete_agent_with_multiple_agent_id(api):
     '''
-    Test case for delete_agent method
+    Test case for agent groups delete_agent method
     '''
     group_id: UUID = 'fs252fdg-4b7c-4d2b-99a1-dvsdsv4242vf'
     payload = {
@@ -202,7 +202,7 @@ def test_delete_agent_with_multiple_agent_id(api):
 @responses.activate
 def test_task_status(api):
     '''
-    Test case for task_status method
+    Test case for agent groups task_status method
     '''
     group_id: UUID = 'fs252fdg-4b7c-4d2b-99a1-dvsdsv4242vf'
     task_id: UUID = '02683e5e-4b7c-4d2b-99a1-cde1ea0940d9'
@@ -229,7 +229,7 @@ def test_task_status(api):
 @responses.activate
 def test_details(api):
     '''
-    Test case for details method
+    Test case for agent groups details method
     '''
     group_id: UUID = 'ea81c0e9-a041-45d6-a654-80570d6bee97'
     filters: tuple = ('platform', 'match', ['window'])
@@ -336,7 +336,7 @@ def test_details(api):
 @responses.activate
 def test_search(api):
     '''
-    Test case for search method
+    Test case for agent groups search method
     '''
     test_response: dict = {
         'agent_groups': [
@@ -420,7 +420,7 @@ def test_search(api):
 @responses.activate
 def test_send_instruction_to_agents_in_group(api):
     '''
-    Test case for Agents send_instruction_to_agents_in_group method
+    Test case for agent groups send_instruction_to_agents_in_group method
     '''
     group_id: UUID = 'ea81c0e9-a041-45d6-a654-80570d6bee97'
     all_agents: bool = True

--- a/tests/io/v3/vm/agent_groups/test_agent_groups_api.py
+++ b/tests/io/v3/vm/agent_groups/test_agent_groups_api.py
@@ -401,10 +401,7 @@ def test_search(api):
     )
     assert isinstance(iterator, SearchIterator)
 
-    exclusions_list = []
-    for item in iterator:
-        exclusions_list.append(item)
-    assert len(exclusions_list) == test_response['pagination']['total']
+    assert len(list(iterator)) == test_response['pagination']['total']
 
     iterator = api.v3.vm.agent_groups.search(
         fields=fields, filter=filter, sort=sort, return_csv=True

--- a/tests/io/v3/vm/agent_groups/test_agent_groups_schema.py
+++ b/tests/io/v3/vm/agent_groups/test_agent_groups_schema.py
@@ -1,20 +1,33 @@
 '''
 Test cases for AgentGroups schemas
 '''
-from tenable.io.v3.vm.agent_groups.schema import AgentGroupSchema
+import pytest
+from marshmallow import ValidationError
+
+from tenable.io.v3.vm.agent_groups.schema import (AgentGroupFilterSchema,
+                                                  AgentGroupSchema,
+                                                  CriteriaSchema,
+                                                  DirectiveSchema)
+from tests.io.v3.vm.agent_groups.objects import (
+    NEGATIVE_AGENT_GROUP_FILTER_SCHEMA, NEGATIVE_AGENT_GROUP_SCHEMA,
+    NEGATIVE_CRITERIA_SCHEMA, NEGATIVE_DIRECTIVE_SCHEMA)
+
+criteria_schema = CriteriaSchema()
+directive_schema = DirectiveSchema()
+agent_group_filter_schema = AgentGroupFilterSchema()
+agent_group_schema = AgentGroupSchema()
 
 
 def test_agent_groups_schema():
     '''
     Test the agent_groups schema with name
     '''
-    schema = AgentGroupSchema()
 
     # Test for schema validation for create/configure agent method
     payload = {
         'name': 'Sample Agent Groups'
     }
-    assert payload == schema.dump(schema.load(payload))
+    assert payload == agent_group_schema.dump(agent_group_schema.load(payload))
 
     # Test for schema validation for add/delete_agents method
     payload = {
@@ -23,7 +36,7 @@ def test_agent_groups_schema():
             '57b74e58-5d95-11ec-bf63-0242ac130002'
         ]
     }
-    assert payload == schema.dump(schema.load(payload))
+    assert payload == agent_group_schema.dump(agent_group_schema.load(payload))
 
     # Test for schema validation for details method
     payload = {
@@ -50,7 +63,7 @@ def test_agent_groups_schema():
         'filter_type': 'and',
         'wildcard_fields': ['name']
     }
-    assert res == schema.dump(schema.load(payload))
+    assert res == agent_group_schema.dump(agent_group_schema.load(payload))
 
     # Test for schema validation for send_instruction_to_agents_in_group method
     payload = {
@@ -65,4 +78,28 @@ def test_agent_groups_schema():
         'not_items': ['334b962a-ac03-4336-9ebb-a06b321576e0'],
         'directive': {'type': 'restart'}
     }
-    assert payload == schema.dump(schema.load(payload))
+    assert payload == agent_group_schema.dump(agent_group_schema.load(payload))
+
+
+@pytest.mark.parametrize("test_input", NEGATIVE_CRITERIA_SCHEMA)
+def test_criteria_schema_negative(test_input):
+    with pytest.raises(ValidationError):
+        criteria_schema.load(test_input)
+
+
+@pytest.mark.parametrize("test_input", NEGATIVE_DIRECTIVE_SCHEMA)
+def test_directive_schema_negative(test_input):
+    with pytest.raises(ValidationError):
+        directive_schema.load(test_input)
+
+
+@pytest.mark.parametrize("test_input", NEGATIVE_AGENT_GROUP_FILTER_SCHEMA)
+def test_agent_group_filter_schema_negative(test_input):
+    with pytest.raises(ValidationError):
+        agent_group_filter_schema.load(test_input)
+
+
+@pytest.mark.parametrize("test_input", NEGATIVE_AGENT_GROUP_SCHEMA)
+def test_agent_group_schema_negative(test_input):
+    with pytest.raises(ValidationError):
+        agent_group_schema.load(test_input)

--- a/tests/io/v3/vm/agent_groups/test_agent_groups_schema.py
+++ b/tests/io/v3/vm/agent_groups/test_agent_groups_schema.py
@@ -4,38 +4,65 @@ Testing the AgentGroups schemas
 from tenable.io.v3.vm.agent_groups.schema import AgentGroupSchema
 
 
-def test_agent_groups_schema_with_name():
+def test_agent_groups_schema():
     '''
     Test the agent_groups schema with name
     '''
-    name: str = 'sample name'
-    payload = {
-        'name': name
-    }
-    test_resp = {
-        'name': name
-    }
     schema = AgentGroupSchema()
-    assert test_resp == schema.dump(schema.load(payload))
 
+    # Test for schema validation for create/configure agent method
+    payload = {
+        'name': 'Sample Agent Groups'
+    }
+    assert payload == schema.dump(schema.load(payload))
 
-def test_agent_groups_schema_with_agent_ids():
-    '''
-    Test the agent_groups schema with agent_ids
-    '''
+    # Test for schema validation for add/delete_agents method
     payload = {
         'items': [
             '57b74c0a-5d95-11ec-bf63-0242ac130002',
-            '57b74e58-5d95-11ec-bf63-0242ac130002',
-            '57b74f66-5d95-11ec-bf63-0242ac130002'
+            '57b74e58-5d95-11ec-bf63-0242ac130002'
         ]
     }
-    test_resp = {
-        'items': [
-            '57b74c0a-5d95-11ec-bf63-0242ac130002',
-            '57b74e58-5d95-11ec-bf63-0242ac130002',
-            '57b74f66-5d95-11ec-bf63-0242ac130002'
-        ]
+    assert payload == schema.dump(schema.load(payload))
+
+    # Test for schema validation for details method
+    payload = {
+        'filters': [('platform', 'match', ['window'])],
+        'filter_type': 'and',
+        'limit': 50,
+        'offset': 0,
+        'sort': [('name', 'asc'), ('platform', 'asc')],
+        'wildcard': 'IYKKQIGOBWXUXOZIBURFENPNMGZOSWBUKVCD',
+        'wildcard_fields': ['name']
     }
-    schema = AgentGroupSchema()
-    assert test_resp == schema.dump(schema.load(payload))
+    res = {
+        'sort': [('name', 'asc'), ('platform', 'asc')],
+        'offset': 0,
+        'filters': [
+            {
+                'value': ['window'],
+                'operator': 'match',
+                'field': 'platform'
+            }
+        ],
+        'wildcard': 'IYKKQIGOBWXUXOZIBURFENPNMGZOSWBUKVCD',
+        'limit': 50,
+        'filter_type': 'and',
+        'wildcard_fields': ['name']
+    }
+    assert res == schema.dump(schema.load(payload))
+
+    # Test for schema validation for send_instruction_to_agents_in_group method
+    payload = {
+        'criteria': {
+            'all_agents': True,
+            'wildcard': 'sdfknskdnf',
+            'filters': ['name:match:laptop'],
+            'filter_type': 'and',
+            'hardcoded_filters': ['core_version:lt:10.0.0']
+        },
+        'items': ['334b962a-ac03-4336-9ebb-a06b169576e0'],
+        'not_items': ['334b962a-ac03-4336-9ebb-a06b321576e0'],
+        'directive': {'type': 'restart'}
+    }
+    assert payload == schema.dump(schema.load(payload))

--- a/tests/io/v3/vm/agent_groups/test_agent_groups_schema.py
+++ b/tests/io/v3/vm/agent_groups/test_agent_groups_schema.py
@@ -1,5 +1,5 @@
 '''
-Testing the AgentGroups schemas
+Test cases for AgentGroups schemas
 '''
 from tenable.io.v3.vm.agent_groups.schema import AgentGroupSchema
 


### PR DESCRIPTION
This PR contains following changes :

Agent Groups API related changes

- removed list method and replace it with search method
- marshmallow schema validation for request body
- Agent Bulk Operation related changes

Agent Bulk Operation API related changes

- added support for below endpoint as part of agent_groups.py module

SDK method -> Corresponding endpoint
send_instruction_to_agents_in_group -> POST api/v3/agent-groups/{group_id}/agents/_bulk/directive